### PR TITLE
chore: add lnd 0.9.1 (DO NOT MERGE)

### DIFF
--- a/lnd.updates/README.md
+++ b/lnd.updates/README.md
@@ -21,6 +21,14 @@ of the LND directory.
     More info about this process in the
     [FAQ](https://github.com/rootzoll/raspiblitz/blob/master/FAQ.md#2-making-a-complete-lnd-data-backup)
 
+### [Update LND to v0.9.1-beta](lnd.update.v0.9.1-beta.sh)
+
+* Run this line in the RaspiBlitz terminal to update:  
+
+    ```bash
+    $ wget https://raw.githubusercontent.com/openoms/lightning-node-management/master/lnd.updates/lnd.update.v0.9.1-beta.sh && bash lnd.update.v0.9.1-beta.sh
+    ```
+
 ### [Update LND to v0.9.0-beta](lnd.update.v0.9.0-beta.sh)
 
 * Run this line in the RaspiBlitz terminal to update:  

--- a/lnd.updates/lnd.update.v0.9.1-beta.sh
+++ b/lnd.updates/lnd.update.v0.9.1-beta.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+# LND Update Script
+
+# Download and run this script on the RaspiBlitz:
+# $ wget https://raw.githubusercontent.com/openoms/lightning-node-management/master/lnd.updates/lnd.update.v0.9.0-beta.sh && bash lnd.update.v0.9.0-beta.sh
+
+# see LND releases: https://github.com/lightningnetwork/lnd/releases
+
+lndVersion="0.9.1-beta"  # the version you would like to be updated
+downloadDir="/home/admin/download"  # edit your download directory
+
+# check who signed the release in https://github.com/lightningnetwork/lnd/releases
+# olaoluwa
+PGPpkeys="https://keybase.io/roasbeef/pgp_keys.asc"
+PGPcheck="9769140D255C759B1EB77B46A96387A57CAAE94D"
+
+#joostjager
+# PGPpkeys="https://keybase.io/joostjager/pgp_keys.asc"
+# PGPcheck="D146D0F68939436268FA9A130E26BB61B76C4D3A"
+
+# bitconner 
+# PGPpkeys="https://keybase.io/bitconner/pgp_keys.asc"
+# PGPcheck="9C8D61868A7C492003B2744EE7D737B67FA592C7"
+
+# wpaulino
+# PGPpkeys="https://keybase.io/wpaulino/pgp_keys.asc"
+# PGPcheck="729E9D9D92C75A5FBFEEE057B5DD717BEF7CA5B1"
+
+echo "Detect CPU architecture ..." 
+isARM=$(uname -m | grep -c 'arm')
+isAARCH64=$(uname -m | grep -c 'aarch64')
+isX86_64=$(uname -m | grep -c 'x86_64')
+isX86_32=$(uname -m | grep -c 'i386\|i486\|i586\|i686\|i786')
+if [ ${isARM} -eq 0 ] && [ ${isAARCH64} -eq 0 ] && [ ${isX86_64} -eq 0 ] && [ ${isX86_32} -eq 0 ] ; then
+  echo "!!! FAIL !!!"
+  echo "Can only build on ARM, aarch64, x86_64 or i386 not on:"
+  uname -m
+  exit 1
+else
+ echo "OK running on $(uname -m) architecture."
+fi
+
+cd "${downloadDir}"
+
+# extract the SHA256 hash from the manifest file for the corresponding platform
+sudo -u admin wget -N https://github.com/lightningnetwork/lnd/releases/download/v${lndVersion}/manifest-v${lndVersion}.txt
+if [ ${isARM} -eq 1 ] ; then
+  lndOSversion="armv7"
+  lndSHA256=$(grep -i "linux-$lndOSversion" manifest-v$lndVersion.txt | cut -d " " -f1)
+fi
+if [ ${isAARCH64} -eq 1 ] ; then
+  lndOSversion="arm64"
+  lndSHA256=$(grep -i "linux-$lndOSversion" manifest-v$lndVersion.txt | cut -d " " -f1)
+fi
+if [ ${isX86_64} -eq 1 ] ; then
+  lndOSversion="amd64"
+  lndSHA256=$(grep -i "linux-$lndOSversion" manifest-v$lndVersion.txt | cut -d " " -f1)
+fi 
+if [ ${isX86_32} -eq 1 ] ; then
+  lndOSversion="386"
+  lndSHA256=$(grep -i "linux-$lndOSversion" manifest-v$lndVersion.txt | cut -d " " -f1)
+fi 
+echo ""
+echo "*** LND v${lndVersion} for ${lndOSversion} ***"
+echo "SHA256 hash: $lndSHA256"
+echo ""
+
+# get LND binary
+binaryName="lnd-linux-${lndOSversion}-v${lndVersion}.tar.gz"
+sudo -u admin wget -N https://github.com/lightningnetwork/lnd/releases/download/v${lndVersion}/${binaryName}
+
+# check binary was not manipulated (checksum test)
+sudo -u admin wget -N https://github.com/lightningnetwork/lnd/releases/download/v${lndVersion}/manifest-v${lndVersion}.txt.sig
+sudo -u admin wget -N -O "${downloadDir}/pgp_keys.asc" ${PGPpkeys}
+binaryChecksum=$(sha256sum ${binaryName} | cut -d " " -f1)
+if [ "${binaryChecksum}" != "${lndSHA256}" ]; then
+  echo "!!! FAIL !!! Downloaded LND BINARY not matching SHA256 checksum: ${lndSHA256}"
+  exit 1
+fi
+
+# check gpg finger print
+gpg ./pgp_keys.asc
+fingerprint=$(sudo gpg "${downloadDir}/pgp_keys.asc" 2>/dev/null | grep "${PGPcheck}" -c)
+if [ ${fingerprint} -lt 1 ]; then
+  echo ""
+  echo "!!! BUILD WARNING --> LND PGP author not as expected"
+  echo "Should contain PGP: ${PGPcheck}"
+  echo "PRESS ENTER to TAKE THE RISK if you think all is OK"
+  read key
+fi
+gpg --import ./pgp_keys.asc
+sleep 3
+verifyResult=$(gpg --verify manifest-v${lndVersion}.txt.sig 2>&1)
+goodSignature=$(echo ${verifyResult} | grep 'Good signature' -c)
+echo "goodSignature(${goodSignature})"
+correctKey=$(echo ${verifyResult} | tr -d " \t\n\r" | grep "${GPGcheck}" -c)
+echo "correctKey(${correctKey})"
+if [ ${correctKey} -lt 1 ] || [ ${goodSignature} -lt 1 ]; then
+  echo ""
+  echo "!!! BUILD FAILED --> LND PGP Verify not OK / signature(${goodSignature}) verify(${correctKey})"
+  exit 1
+fi
+
+sudo systemctl stop lnd
+
+# install
+sudo -u admin tar -xzf ${binaryName}
+sudo install -m 0755 -o root -g root -t /usr/local/bin lnd-linux-${lndOSversion}-v${lndVersion}/*
+sleep 3
+installed=$(sudo -u admin lnd --version)
+if [ ${#installed} -eq 0 ]; then
+  echo ""
+  echo "!!! BUILD FAILED --> Was not able to install LND"
+  exit 1
+fi
+
+sudo systemctl start lnd
+
+sleep 5
+echo ""
+echo "Installed ${installed}"
+
+sleep 15
+lncli unlock


### PR DESCRIPTION
EDIT: `0.9.1` would randomly crash for me with `11/SEGV` (see below). I am back to `0.9.0` and things are stable again.

```
Mar 02 16:37:37 ABC systemd[1]: Starting LND Lightning Daemon...
Mar 02 16:37:37 ABC systemd[1]: Started LND Lightning Daemon.
Mar 02 18:37:13 ABC systemd[1]: lnd.service: Main process exited, code=killed, status=11/SEGV
Mar 02 18:37:13 ABC systemd[1]: lnd.service: Failed with result 'signal'.
Mar 02 18:38:13 ABC systemd[1]: lnd.service: Service RestartSec=1min expired, scheduling restart.
Mar 02 18:38:13 ABC systemd[1]: lnd.service: Scheduled restart job, restart counter is at 1.
Mar 02 18:38:13 ABC systemd[1]: Stopped LND Lightning Daemon.
Mar 02 18:38:13 ABC systemd[1]: Starting LND Lightning Daemon...
Mar 02 18:38:13 ABC systemd[1]: Started LND Lightning Daemon.
Mar 02 20:50:10 ABC systemd[1]: lnd.service: Main process exited, code=killed, status=11/SEGV
Mar 02 20:50:10 ABC systemd[1]: lnd.service: Failed with result 'signal'.
Mar 02 20:51:10 ABC systemd[1]: lnd.service: Service RestartSec=1min expired, scheduling restart.
Mar 02 20:51:10 ABC systemd[1]: lnd.service: Scheduled restart job, restart counter is at 2.
Mar 02 20:51:10 ABC systemd[1]: Stopped LND Lightning Daemon.
Mar 02 20:51:10 ABC systemd[1]: Starting LND Lightning Daemon...
Mar 02 20:51:10 ABC systemd[1]: Started LND Lightning Daemon.
Mar 02 21:27:11 ABC systemd[1]: lnd.service: Main process exited, code=killed, status=11/SEGV
Mar 02 21:27:11 ABC systemd[1]: lnd.service: Failed with result 'signal'.
Mar 02 21:28:11 ABC systemd[1]: lnd.service: Service RestartSec=1min expired, scheduling restart.
Mar 02 21:28:11 ABC systemd[1]: lnd.service: Scheduled restart job, restart counter is at 3.
Mar 02 21:28:11 ABC systemd[1]: Stopped LND Lightning Daemon.
Mar 02 21:28:11 ABC systemd[1]: Starting LND Lightning Daemon...
```

Since `11/SEGV` hints at a memory access violation and I can't be sure this to be specific to my environment, I think it's a good idea for others (@openoms @jlopp @saubyk @CandleHater @rootzoll) to test-run this and report back. Goes without saying: don't run on a production/routing node.