### PR TITLE
Update RaspiBolt section

### DIFF
--- a/hardware/raspibolt.md
+++ b/hardware/raspibolt.md
@@ -2,17 +2,24 @@
 
 ## Main guide
 
-Manually build your own Lightning & Bitcoin full node on a Raspberry Pi.<br>
-Get started at [raspibolt.github.io/raspibolt/](https://raspibolt.github.io/raspibolt/)
+Manually build your own Bitcoin & Lightning full node on a Raspberry Pi.  
+
+Get started at [https://raspibolt.org/](https://raspibolt.org/)
 
 ## Extra guides (i.e. not yet merged in the main RaspiBolt guide)
-Some of them might be outdated, to be used with discernment!
 
-* [Balance of Satoshis & Telegram Bot](https://github.com/raspibolt/raspibolt/blob/9863b15b7fcfc056b01fb19aebd3af34f6f82caa/raspibolt_78_balanceofsatoshis.md)
-* [Circuit Breaker](https://github.com/raspibolt/raspibolt/blob/21ee27bac84644e0bbbee513213285f57c986f82/raspibolt_80_circuitbreaker.md)
-* [How to download the white paper from the blockchain](https://github.com/raspibolt/raspibolt/blob/2a604d70819470e2b87f1957b6745a172d4a087a/raspibolt_90_whitepaper.md)
-* [nodeeyez](https://github.com/vicariousdrama/nodeyez)
-* [Ride The Lightning](https://github.com/raspibolt/raspibolt/issues/652)
-* [ThunderHub](https://github.com/raspibolt/raspibolt/blob/940d050bbabd2e2be948d8600ed98d702d2fdc06/raspibolt_78_thunderhub.md)
-* [Upgrade from 32-bit Raspibolt to Ubuntu Server 64-bit OS](https://gist.github.com/acburkhardt/b3d8d5f61823b7119d58364f56a8c0a5)
-* [WireGuard](https://github.com/raspibolt/raspibolt/blob/b9183db4cce84280c38fd9273b312aefb2b4aac0/raspibolt_76_WireGuard_VPN.md)
+* [Balance of Satoshis & Telegram Bot](https://github.com/raspibolt/raspibolt/blob/c2126ed38c048663b63ae67126a6e06d45442458/bonus/lightning/balance-of-satoshis.md): a CLI tool to work with LND channel balances, create a node monitoring Telegram bot and that has many other useful features
+
+* [charge-lnd](https://github.com/raspibolt/raspibolt/blob/bc9f862fe035b7178ddaae9e6a6e661a05d17186/bonus/lightning/charge-lnd.md): a simple policy based fee manager for LND
+
+* [Circuit Breaker](https://github.com/raspibolt/raspibolt/blob/f21fb264ee53376705cd3611ddce8213db11a344/bonus/lightning/circuit-breaker.md): a lightning "firewall" that protects your node against HTLCs flooding attacks
+
+* [nodeeyez](https://github.com/vicariousdrama/nodeyez): display panels to get the most from your node
+
+* [rebalance-lnd](https://github.com/raspibolt/raspibolt/blob/80317f8f361e4cf24b694cc7bda58bbfc6b66456/bonus/lightning/rebalance-lnd.md): a CLI tool to manage your channel liquidity by doing circular rebalancing
+
+* [ThunderHub](https://github.com/raspibolt/raspibolt/blob/940d050bbabd2e2be948d8600ed98d702d2fdc06/raspibolt_78_thunderhub.md): a web GUI to manage your node locally or remotely via Tor
+
+* [Upgrade from 32-bit Raspibolt to Ubuntu Server 64-bit OS](https://gist.github.com/acburkhardt/b3d8d5f61823b7119d58364f56a8c0a5): how to convert a 32-bit legacy RaspiBolt node to 64-bit OS (not compatible with RaspiBolt v3)
+
+* [WireGuard](https://github.com/raspibolt/raspibolt/blob/b9183db4cce84280c38fd9273b312aefb2b4aac0/raspibolt_76_WireGuard_VPN.md): (outdated guide) a VPN you can install to access your RaspiBolt from outside without openning more than one port of your route


### PR DESCRIPTION
This PR is to update the RaspiBolt page in the Hardware section.

* The main guide is now accessible via its own domain name at: raspibolt.org

* Most of the links to the extra guides were broken, I updated them

* Added a short description of each extra guide and new ones and removed one that has been merged into the main guide

* A few formatting improvement
