### PR TITLE
A restart of LND is needed to add wtclient

### DIFF
--- a/advanced-tools/watchtower.md
+++ b/advanced-tools/watchtower.md
@@ -78,7 +78,9 @@ Run the commands in the node\`s terminal
     wtclient.active=1
     ```
 
-    Add a watchtower from the command line \(can add multiple one-by-one\):
+  * restart lnd `# systemctl restart lnd`
+
+  * Add a watchtower from the command line \(can add multiple one-by-one\):
 
     ```text
     $ lncli wtclient add <watchtower-pubkey>@<host>:9911


### PR DESCRIPTION
Not sure if the later "restart lnd" is needed, but here it's needed for sure. If not:

```
admin@192.168.1.2:~ ₿ lncli wtclient add pubkey@onion_host_address.onion:9911
[lncli] rpc error: code = Unknown desc = watchtower client not active
```