### PR TITLE
Fix broken link to networking.md

### DIFF
--- a/hardware/recommendations.md
+++ b/hardware/recommendations.md
@@ -38,7 +38,7 @@ Shopping list with keywords: <https://github.com/rootzoll/raspiblitz#amazon-shop
 - Muliple disks to use a checksumming, "self-healing" software RAID like ZFS
 - Avoid hardware RAID cards - often another source of problems and recovery is not possible with other hardware
 ## Use a minimal VPS with ZeroTier or Tailscale to tunnel services to a public domain
-* [VPN tunnels](technicals/networking.md)
+* [VPN tunnels](../technicals/networking.md)
 
 ## Build guides:
   - [Raspibolt](https://raspibolt.org/)


### PR DESCRIPTION
The link in [this section](https://github.com/openoms/lightning-node-management/blob/en/hardware/recommendations.md#use-a-minimal-vps-with-zerotier-or-tailscale-to-tunnel-services-to-a-public-domain) to "VPN tunnels" is currently broken when browsing the guide on GitHub.